### PR TITLE
feat: Add AI Optimized power mode and AI power assistant

### DIFF
--- a/data/MainWindow.ui
+++ b/data/MainWindow.ui
@@ -168,6 +168,49 @@
                         <property name="position">2</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkButton" id="ui_button_ai_optimized">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="pixbuf">ppm-balanced-button.svg</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">AI OPTIMIZED</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/data/config.ini
+++ b/data/config.ini
@@ -34,3 +34,10 @@
 #backlight-powersave=%50
 #powersave_threshold=25
 #charge_stop_enabled=false
+
+[ai_assistant]
+# Enable or disable the AI assistant features for the "AI Optimized" mode
+enabled = true
+# Default mode to use for "AI Optimized" if the assistant is disabled
+# Valid options: performance, balanced, powersave
+default_mode = balanced

--- a/src/client/MainWindow.py
+++ b/src/client/MainWindow.py
@@ -37,6 +37,7 @@ actions_file = os.path.dirname(os.path.abspath(__file__)) + "/actions.py"
 _("powersave")
 _("balanced")
 _("performance")
+_("ai_optimized")
 
 class MainWindow:
 
@@ -129,6 +130,7 @@ class MainWindow:
         self.o("ui_button_powersave").connect("clicked",self.powersave_event)
         self.o("ui_button_balanced").connect("clicked",self.balanced_event)
         self.o("ui_button_performance").connect("clicked",self.performance_event)
+        self.o("ui_button_ai_optimized").connect("clicked",self.ai_optimized_event)
         self.o("ui_combobox_acmode").connect("changed",self.save_settings)
         self.o("ui_combobox_batmode").connect("changed",self.save_settings)
         self.o("ui_combobox_osi").connect("changed",self.save_settings)
@@ -187,6 +189,7 @@ class MainWindow:
         store = Gtk.ListStore(str, str)
         store.append([_("Performance"),"performance"])
         store.append([_("Balanced"),"balanced"])
+        store.append([_("AI Optimized"),"ai_optimized"])
         store.append([_("Powersave"),"powersave"])
         store.append([_("Do Noting"),"ignore"])
         self.o("ui_combobox_acmode").set_model(store)
@@ -227,7 +230,7 @@ class MainWindow:
     def value_init(self):
         self.o("ui_spinbutton_switch_to_performance").set_value(float(get("powersave_threshold","25","modes")))
         self.o("ui_checkbox_battery_treshold").set_active(get("charge_stop_enabled","False","modes").lower() == "true")
-        l = ["performance", "balanced", "powersave", "ignore"]
+        l = ["performance", "balanced", "ai_optimized", "powersave", "ignore"]
         self.o("ui_combobox_acmode").set_active(l.index(get("ac-mode","balanced","modes")))
         self.o("ui_combobox_batmode").set_active(l.index(get("bat-mode","powersave","modes")))
 
@@ -259,7 +262,10 @@ class MainWindow:
                 elif self.current_mode == "balanced":
                     self.power_mode.set_label(_("Enable Powersave"))
                     self.indicator.set_icon("pardus-pm-balanced-symbolic")
-                else:
+                elif self.current_mode == "ai_optimized":
+                    self.power_mode.set_label(_("Enable Powersave")) # Or a different label if desired
+                    self.indicator.set_icon("pardus-pm-balanced-symbolic") # Or a new icon ppm-ai-optimized-symbolic
+                else: # performance
                     self.power_mode.set_label(_("Enable Powersave"))
                     self.indicator.set_icon("pardus-pm-performance-symbolic")
         if "backlight" in data:
@@ -277,14 +283,22 @@ class MainWindow:
             self.o("ui_button_powersave").set_sensitive(False)
             self.o("ui_button_balanced").set_sensitive(True)
             self.o("ui_button_performance").set_sensitive(True)
+            self.o("ui_button_ai_optimized").set_sensitive(True)
         elif self.current_mode == "balanced":
             self.o("ui_button_powersave").set_sensitive(True)
             self.o("ui_button_balanced").set_sensitive(False)
             self.o("ui_button_performance").set_sensitive(True)
-        else:
+            self.o("ui_button_ai_optimized").set_sensitive(True)
+        elif self.current_mode == "ai_optimized":
+            self.o("ui_button_powersave").set_sensitive(True)
+            self.o("ui_button_balanced").set_sensitive(True)
+            self.o("ui_button_performance").set_sensitive(True)
+            self.o("ui_button_ai_optimized").set_sensitive(False)
+        else: # performance
             self.o("ui_button_powersave").set_sensitive(True)
             self.o("ui_button_balanced").set_sensitive(True)
             self.o("ui_button_performance").set_sensitive(False)
+            self.o("ui_button_ai_optimized").set_sensitive(True)
 
         if "info" in data:
             acpi = not (str(data["info"]["acpi-supported"]).lower() == "true")
@@ -404,6 +418,16 @@ class MainWindow:
         data = {}
         data["pid"] = os.getpid()
         data["new-mode"] = "performance"
+        send_server(data)
+
+    def ai_optimized_event(self,widget):
+        self.o("ui_button_powersave").set_sensitive(True)
+        self.o("ui_button_balanced").set_sensitive(True)
+        self.o("ui_button_performance").set_sensitive(True)
+        self.o("ui_button_ai_optimized").set_sensitive(False)
+        data = {}
+        data["pid"] = os.getpid()
+        data["new-mode"] = "ai_optimized"
         send_server(data)
 
 ###### Window functions ######

--- a/src/client/cli.py
+++ b/src/client/cli.py
@@ -5,6 +5,7 @@ import json
 def usage():
     print(sys.argv)
     print("Usage: ppm [set/get] [mode/backlight/battery/info] (value)")
+    print("  Modes: performance, balanced, powersave, ai_optimized")
     exit(1)
 
 if len(sys.argv) <= 2 and (len(sys.argv) < 2 or sys.argv[1] != "show"):

--- a/src/service/ai_assistant.py
+++ b/src/service/ai_assistant.py
@@ -1,0 +1,34 @@
+import random
+
+class AIAssistant:
+    """
+    A placeholder for the AI Power Assistant.
+    Provides recommendations for power modes.
+    """
+
+    def __init__(self):
+        """
+        Initializes the AI Assistant.
+        """
+        self.available_modes = ['performance', 'balanced', 'powersave']
+
+    def get_recommendation(self) -> str:
+        """
+        Provides a power mode recommendation.
+
+        For now, this method randomly selects one of the existing
+        power modes.
+
+        Returns:
+            str: The recommended power mode ('performance', 'balanced', or 'powersave').
+        """
+        return random.choice(self.available_modes)
+
+if __name__ == '__main__':
+    # Example usage:
+    assistant = AIAssistant()
+    recommendation = assistant.get_recommendation()
+    print(f"Recommended power mode: {recommendation}")
+
+    recommendation = assistant.get_recommendation()
+    print(f"Another recommended power mode: {recommendation}")

--- a/src/service/tests/__init__.py
+++ b/src/service/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes src/service/tests a Python package.

--- a/src/service/tests/test_power_modes.py
+++ b/src/service/tests/test_power_modes.py
@@ -1,0 +1,171 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Assuming src is in PYTHONPATH or tests are run from a context where it's discoverable
+from service.ai_assistant import AIAssistant
+from service.backends import power as power_module # Use alias to avoid conflict with power function if any
+from service import common # To mock common.get
+
+class TestAIAssistant(unittest.TestCase):
+    def test_get_recommendation_validity(self):
+        """
+        Tests that AIAssistant.get_recommendation() returns a valid mode.
+        """
+        assistant = AIAssistant()
+        recommendation = assistant.get_recommendation()
+        self.assertIn(recommendation, assistant.available_modes,
+                      f"Recommendation '{recommendation}' is not in available modes.")
+
+class TestAIOptimizedMode(unittest.TestCase):
+    def setUp(self):
+        """
+        Set up mocks that are common across tests for _ai_optimized.
+        """
+        # Mock the actual power-setting functions
+        self.patcher_performance = patch('service.backends.power._performance', MagicMock(spec=power_module._performance))
+        self.patcher_balanced = patch('service.backends.power._balanced', MagicMock(spec=power_module._balanced))
+        self.patcher_powersave = patch('service.backends.power._powersave', MagicMock(spec=power_module._powersave))
+
+        self.mock_performance = self.patcher_performance.start()
+        self.mock_balanced = self.patcher_balanced.start()
+        self.mock_powersave = self.patcher_powersave.start()
+
+        # Mock common.get for configuration
+        self.patcher_common_get = patch('service.common.get') # Patching where it's looked up (service.common)
+        self.mock_common_get = self.patcher_common_get.start()
+
+        # Mock AIAssistant's get_recommendation method
+        self.patcher_ai_get_recommendation = patch('service.ai_assistant.AIAssistant.get_recommendation')
+        self.mock_ai_get_recommendation = self.patcher_ai_get_recommendation.start()
+
+        # Mock log to suppress output during tests
+        self.patcher_log = patch('service.backends.power.log', MagicMock())
+        self.mock_log = self.patcher_log.start()
+
+        # Make sure to stop patches
+        self.addCleanup(self.patcher_performance.stop)
+        self.addCleanup(self.patcher_balanced.stop)
+        self.addCleanup(self.patcher_powersave.stop)
+        self.addCleanup(self.patcher_common_get.stop)
+        self.addCleanup(self.patcher_ai_get_recommendation.stop)
+        self.addCleanup(self.patcher_log.stop)
+
+    def _reset_power_mocks(self):
+        self.mock_performance.reset_mock()
+        self.mock_balanced.reset_mock()
+        self.mock_powersave.reset_mock()
+
+    def test_ai_enabled_recommends_performance(self):
+        self._reset_power_mocks()
+        self.mock_common_get.side_effect = lambda key, default, section: "true" if key == "enabled" and section == "ai_assistant" else default
+        self.mock_ai_get_recommendation.return_value = "performance"
+
+        power_module._ai_optimized()
+
+        self.mock_ai_get_recommendation.assert_called_once()
+        self.mock_performance.assert_called_once()
+        self.mock_balanced.assert_not_called()
+        self.mock_powersave.assert_not_called()
+
+    def test_ai_enabled_recommends_balanced(self):
+        self._reset_power_mocks()
+        self.mock_common_get.side_effect = lambda key, default, section: "true" if key == "enabled" and section == "ai_assistant" else default
+        self.mock_ai_get_recommendation.return_value = "balanced"
+
+        power_module._ai_optimized()
+
+        self.mock_ai_get_recommendation.assert_called_once()
+        self.mock_performance.assert_not_called()
+        self.mock_balanced.assert_called_once()
+        self.mock_powersave.assert_not_called()
+
+    def test_ai_enabled_recommends_powersave(self):
+        self._reset_power_mocks()
+        self.mock_common_get.side_effect = lambda key, default, section: "true" if key == "enabled" and section == "ai_assistant" else default
+        self.mock_ai_get_recommendation.return_value = "powersave"
+
+        power_module._ai_optimized()
+
+        self.mock_ai_get_recommendation.assert_called_once()
+        self.mock_performance.assert_not_called()
+        self.mock_balanced.assert_not_called()
+        self.mock_powersave.assert_called_once()
+
+    def test_ai_enabled_recommends_invalid_falls_back_to_balanced(self):
+        self._reset_power_mocks()
+        self.mock_common_get.side_effect = lambda key, default, section: "true" if key == "enabled" and section == "ai_assistant" else default
+        self.mock_ai_get_recommendation.return_value = "invalid_mode"
+
+        power_module._ai_optimized()
+
+        self.mock_ai_get_recommendation.assert_called_once()
+        self.mock_performance.assert_not_called()
+        self.mock_balanced.assert_called_once() # Fallback
+        self.mock_powersave.assert_not_called()
+
+    def test_ai_disabled_uses_default_mode_performance(self):
+        self._reset_power_mocks()
+        def config_side_effect(key, default, section):
+            if section == "ai_assistant":
+                if key == "enabled": return "false"
+                if key == "default_mode": return "performance"
+            return default
+        self.mock_common_get.side_effect = config_side_effect
+
+        power_module._ai_optimized()
+
+        self.mock_ai_get_recommendation.assert_not_called()
+        self.mock_performance.assert_called_once()
+        self.mock_balanced.assert_not_called()
+        self.mock_powersave.assert_not_called()
+
+    def test_ai_disabled_uses_default_mode_balanced(self):
+        self._reset_power_mocks()
+        def config_side_effect(key, default, section):
+            if section == "ai_assistant":
+                if key == "enabled": return "false"
+                if key == "default_mode": return "balanced"
+            return default
+        self.mock_common_get.side_effect = config_side_effect
+
+        power_module._ai_optimized()
+
+        self.mock_ai_get_recommendation.assert_not_called()
+        self.mock_performance.assert_not_called()
+        self.mock_balanced.assert_called_once()
+        self.mock_powersave.assert_not_called()
+
+    def test_ai_disabled_uses_default_mode_powersave(self):
+        self._reset_power_mocks()
+        def config_side_effect(key, default, section):
+            if section == "ai_assistant":
+                if key == "enabled": return "false"
+                if key == "default_mode": return "powersave"
+            return default
+        self.mock_common_get.side_effect = config_side_effect
+
+        power_module._ai_optimized()
+
+        self.mock_ai_get_recommendation.assert_not_called()
+        self.mock_performance.assert_not_called()
+        self.mock_balanced.assert_not_called()
+        self.mock_powersave.assert_called_once()
+
+    def test_ai_disabled_invalid_default_mode_falls_back_to_balanced(self):
+        self._reset_power_mocks()
+        def config_side_effect(key, default, section):
+            if section == "ai_assistant":
+                if key == "enabled": return "false"
+                if key == "default_mode": return "invalid_config_mode"
+            return default
+        self.mock_common_get.side_effect = config_side_effect
+
+        power_module._ai_optimized()
+
+        self.mock_ai_get_recommendation.assert_not_called()
+        self.mock_performance.assert_not_called()
+        self.mock_balanced.assert_called_once() # Fallback
+        self.mock_powersave.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This commit introduces a new "AI Optimized" power mode and a foundational AI power assistant.

Key features:
- New "AI Optimized" power mode that dynamically selects an underlying power profile (performance, balanced, or powersave) based on the AI assistant's recommendation.
- A basic AI power assistant (`src/service/ai_assistant.py`) that currently provides random recommendations. This is designed to be extended with more sophisticated logic in the future.
- UI elements (button in GUI, option in CLI) for selecting the "AI Optimized" mode.
- Configuration options in `data/config.ini` under `[ai_assistant]` to:
    - Enable/disable the AI assistant (`enabled`).
    - Set a default mode (`default_mode`) if the assistant is disabled.
- Unit tests for the new power mode logic and the AI assistant, ensuring correct behavior under different configurations and recommendations.

The "AI Optimized" mode, when the AI assistant is enabled, calls the assistant to get a power mode recommendation. If disabled, it falls back to a user-configurable default mode. The underlying power settings for performance, balanced, and powersave modes remain unchanged.